### PR TITLE
Complete move of org (bcgov-nr -> bcgov) with SonarCloud

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -158,10 +158,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: sonar-scanner
              -Dsonar.login=${{ secrets.SONAR_TOKEN }}
-             -Dsonar.organization=bcgov
+             -Dsonar.organization=bcgov-sonarcloud
              -Dsonar.host.url=https://sonarcloud.io
              -Dsonar.projectKey=bcgov_greenfield-pipeline
-             -Dsonar.exclusions=**/*.java
              -Dsonar.sourceEncoding=UTF-8
 
   zap:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -160,7 +160,7 @@ jobs:
              -Dsonar.login=${{ secrets.SONAR_TOKEN }}
              -Dsonar.organization=bcgov
              -Dsonar.host.url=https://sonarcloud.io
-             -Dsonar.projectKey=greenfield-pipeline
+             -Dsonar.projectKey=bcgov_greenfield-pipeline
              -Dsonar.exclusions=**/*.java
              -Dsonar.sourceEncoding=UTF-8
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -158,7 +158,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: sonar-scanner
              -Dsonar.login=${{ secrets.SONAR_TOKEN }}
-             -Dsonar.organization=bcgov-nr
+             -Dsonar.organization=bcgov
              -Dsonar.host.url=https://sonarcloud.io
              -Dsonar.projectKey=greenfield-pipeline
              -Dsonar.exclusions=**/*.java

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,3 +6,5 @@ async function bootstrap () {
   await app.listen(3000)
 }
 bootstrap()
+
+// Junk commit

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,5 +6,3 @@ async function bootstrap () {
   await app.listen(3000)
 }
 bootstrap()
-
-// Junk commit


### PR DESCRIPTION
SonarCloud hasn't been moved until this PR.  It required an issue via Platform Team.  I accidentally threw up a block by keeping greenfield-pipeline in the bcgov-nr organization.

https://github.com/BCDevOps/devops-requests/issues/1373